### PR TITLE
add the possibility that a person can go to the second nearest store

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ So what is "life" in a pandemic lockdown situation (where almost all nations are
 * PROB_HOUSE_INFECTION : probability of getting infected if an infected individual lives in the same house (defaut 0.5)
 * PROB_WORK_INFECTION : probability of getting infected if an infected individual works in the same place (default 0.1)
 * PROB_STORE_INFECTION : probability of getting infected if an infected individual shops at the same store (default 0.05 since we tend to spend less time in a store)
-* [ LOWER_INFECTION_BOUND, UPPER_INFECTION_BOUND ] : random number range to generate time to decision (death/immunity) 
-* [ LOWER_CONTAGION_BOUND, UPPER_CONTAGION_BOUND ] : random number range to generate time to becoming conatigous (death/immunity) 
+* [ LOWER_INFECTION_BOUND, UPPER_INFECTION_BOUND ] : random number range to generate time to decision (death/immunity)
+* [ LOWER_CONTAGION_BOUND, UPPER_CONTAGION_BOUND ] : random number range to generate time to becoming conatigous (death/immunity)
 
 
 All those parameters can be discussed and will be enriched as I keep enhancing this simulation model.
@@ -58,7 +58,7 @@ it definitely does not look like a Gaussian distribution but more like a Poisson
 
 # Backlog
 - [x]  Work is only on week days, weekend need to be removed
-- [ ] You may go to the second nearest grocerie store instead of the closest one (as implemented)
+- [x] You may go to the second nearest grocerie store instead of the closest one (as implemented)
 - [ ]  You probably won't go to the grocerie store every day, but probably twice in week day and once on the weekend (that could be a random variable)
 - [ ]  Infection can and often occurs on public transportation. We need to build a basic transport model with infection probabilities
 - [ ]  Inject the famous covid-19 2.3 R0 into the code somewhere to get realistic results

--- a/initiator/core.py
+++ b/initiator/core.py
@@ -89,10 +89,13 @@ def build_geo_positions_store(number_store_arg):
 def build_geo_positions_workplace(number_workpolace_arg):
     return [(get_center_squized_random(), get_center_squized_random()) for i in range(number_workpolace_arg)]
 
+def get_store_index(indexes, prob_preference_store):
+    return [index[0] if get_r()<prob_preference_store else index[1]  for index in indexes]
 
-def build_house_store_map(geo_position_store_arg, geo_position_house_arg):
-    distance, indexes = spatial.KDTree(geo_position_store_arg).query(geo_position_house_arg)
-    all_hou_sto = dict(zip(range(len(geo_position_house_arg)), indexes))
+
+def build_house_store_map(geo_position_store_arg, geo_position_house_arg,prob_preference_store):
+    distance, indexes = spatial.KDTree(geo_position_store_arg).query(geo_position_house_arg,k=2)
+    all_hou_sto = dict(zip(range(len(geo_position_house_arg)), get_store_index(indexes, prob_preference_store)))
     return all_hou_sto
 
 
@@ -121,4 +124,3 @@ def build_individual_work_map(individual_adult_map_arg):
 def build_workplace_individual_map(individual_workplace_map_arg):
     # workplace -> Individuals
     return invert_map(individual_workplace_map_arg)
-

--- a/simulator/main.py
+++ b/simulator/main.py
@@ -14,13 +14,14 @@ INITIAL_INNOCULATION_PCT = 0.005  # Proportion of people innoculated at day 0
 PROB_HOUSE_INFECTION = 0.5  # Probabilty of infecting a random family member (same house)
 PROB_WORK_INFECTION = 0.1  # Probabilty of infecting a random co-worker
 PROB_STORE_INFECTION = 0.05  # Probabilty of infecting someone who goes to the same store
+PROB_PREFERENCE_STORE=0.7 # Probality of goieng to the nearest store => (1-PROB_PREFERENCE_STORE) the probability of the goeing to the second nearest store
 INFECTION_BOUNDS = (21, 39)
 CONTAGION_BOUNDS = (2, 7)
 
 
 def run_simulation():
     print('Preparing environment...')
-    env_dic = get_environment_simulation(N_INDIVIDUALS, PROBA_SAME_HOUSE_RATE, NB_STORE_PER_HOUSE)
+    env_dic = get_environment_simulation(N_INDIVIDUALS, PROBA_SAME_HOUSE_RATE, NB_STORE_PER_HOUSE,PROB_PREFERENCE_STORE)
     print('Preparing virus conditions...')
     virus_dic = get_virus_simulation_t0(N_INDIVIDUALS, INITIAL_INNOCULATION_PCT, INFECTION_BOUNDS, CONTAGION_BOUNDS)
 

--- a/simulator/simulation_helper.py
+++ b/simulator/simulation_helper.py
@@ -7,7 +7,7 @@ from simulator.dynamic_helper import get_infection_parameters
 from simulator.keys import *
 
 
-def get_environment_simulation(number_of_individuals_arg, same_house_rate_arg, number_store_per_house_arg):
+def get_environment_simulation(number_of_individuals_arg, same_house_rate_arg, number_store_per_house_arg,preference_store_arg):
     all_ind_hou = build_individual_houses_map(number_of_individuals_arg, same_house_rate_arg)
     all_hou_ind = build_house_individual_map(all_ind_hou)
     all_ind_adu = build_individual_adult_map(all_ind_hou)
@@ -21,7 +21,7 @@ def get_environment_simulation(number_of_individuals_arg, same_house_rate_arg, n
     geo_wor = build_geo_positions_workplace(len(all_wor_ind))
     geo_sto = build_geo_positions_store(int(len(all_hou_ind) / number_store_per_house_arg))
 
-    all_hou_sto = build_house_store_map(geo_sto, geo_hou)
+    all_hou_sto = build_house_store_map(geo_sto, geo_hou,preference_store_arg)
     all_sto_hou = build_store_house_map(all_hou_sto)
 
     return {

--- a/tests/initiator_test.py
+++ b/tests/initiator_test.py
@@ -77,10 +77,10 @@ class TestInitiation(unittest.TestCase):
         self.assertEqual(result, {0: [0, 1], 1: [4, 5], 2: [7, 8], 3: [9]})
 
     def test_build_house_store_map(self):
-        geo_position_store = [(5, 5), (4, 4), (3, 3), (2, 2), (1, 1)]
-        geo_position_house = [(5.1, 5.2), (4.1, 4.2), (3.1, 3.2), (2.1, 2.2), (1.1, 1.2)]
-        result = build_house_store_map(geo_position_store, geo_position_house)
-        self.assertEqual(result, {0: 0, 1: 1, 2: 2, 3: 3, 4: 4})
+        geo_position_store = [(6,6),(5, 5), (4, 4), (3, 3), (2, 2), (1, 1)]
+        geo_position_house = [(6.1,6.2),(5.1, 5.2), (4.1, 4.2), (3.1, 3.2), (2.1, 2.2), (1.1, 1.2)]
+        result = build_house_store_map(geo_position_store, geo_position_house,0.5)
+        self.assertEqual(result, {0: 0, 1: 0, 2: 1, 3: 3, 4: 4,5:5})
 
     def test_build_individual_work_map(self):
         input_individual_adult_map = {
@@ -95,4 +95,3 @@ class TestInitiation(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -41,7 +41,7 @@ class TestSimulation(unittest.TestCase):
         }
 
     def test_build_environment_dic(self):
-        result = get_environment_simulation(10, 0.1, 2)
+        result = get_environment_simulation(10, 0.1, 2,1)
         expected_result = TestSimulation.get_10_01_2_environment_dic()
         self.assertEqual(result, expected_result)
 
@@ -277,4 +277,3 @@ class TestSimulation(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
as said in the commit message, i add possibility that a person can go to the second nearest store. 
this possibility is implemented by a probability that a person chooses the nearest store or not, I named it "PROB_PREFERENCE_STORE" and it setted on 0.7 in the main.

the current structure of the code  assign one store per household once and for all. maybe we need to remove "store house construction" from "get_environment_simulation", and put it in the loop, so we add flexibility for a person to change its store from one day to an other  if he want
