### PR TITLE
Add a truncated normal distribution for build_individual_houses_map

### DIFF
--- a/initiator/core.py
+++ b/initiator/core.py
@@ -2,31 +2,28 @@ import random
 
 from scipy import spatial
 
-from initiator.helper import get_r, invert_map, pick_age, get_center_squized_random, pick_random_company_size, \
+from initiator.helper import get_r, get_indiv,invert_map, pick_age, get_center_squized_random, pick_random_company_size, \
     rec_get_manhattan_walk, invert_map_list
 
 
-def build_individual_houses_map(number_individual_arg, proba_same_house_rate):
+def build_individual_houses_map(number_individual_arg):
     # Individual -> House
     all_ind_hou = {}
     i_hou = 0
     i_ind = 0
     is_first_person = True
     prob_keep_hou = get_r()
-    while i_ind < number_individual_arg:
-        if is_first_person:
-            all_ind_hou[i_ind] = i_hou  # Attach first person to the house
-            i_ind = i_ind + 1  # GOTO next person
-            is_first_person = False
-            continue
-        if prob_keep_hou > proba_same_house_rate:
-            all_ind_hou[i_ind] = i_hou  # Attach Next person
-            i_ind = i_ind + 1  # GOTO next person
-            prob_keep_hou = prob_keep_hou / 2  # Divide probability keep_foy
-        else:
-            i_hou = i_hou + 1  # GOTO next house
-            prob_keep_hou = get_r()  # RESET keep_hou probability
-            is_first_person = True  # New house needs a first person
+    while i_ind < number_individual_arg :
+        family_members=get_indiv()
+        individulas=list(range(i_ind,i_ind+family_members))
+        index_house=[i_hou]*family_members
+        one_house=dict(zip(individulas, index_house))
+        all_ind_hou.update(one_house)
+        i_ind=i_ind+family_members
+        i_hou+=1
+    # eliminate side effects
+    for i in range((len(all_ind_hou)-1),number_individual_arg-1,-1):
+        del all_ind_hou[i]
     return all_ind_hou
 
 

--- a/initiator/helper.py
+++ b/initiator/helper.py
@@ -1,6 +1,7 @@
 import random
-
+from scipy.stats import truncnorm
 import pandas as pd
+import math
 
 from initiator.parameters import covid_mortality_rate, covid_hospitalization_rate, world_age_distribution, \
     TPE_MAX_EMPLOYEES, PME_MAX_EMPLOYEES, GE_MAX_EMPLOYEES
@@ -8,7 +9,13 @@ from initiator.parameters import covid_mortality_rate, covid_hospitalization_rat
 
 def get_r():
     return random.random()
-
+def get_indiv():
+    myclip_a = 1
+    myclip_b = 10
+    my_mean = 4.52
+    my_std = math.sqrt(4.71)
+    a, b = (myclip_a - my_mean) / my_std, (myclip_b - my_mean) / my_std
+    return truncnorm.rvs(a, b, loc = my_mean, scale = my_std).astype(int)
 
 def get_random_choice_list(list_of_list_arg):
     result = []

--- a/scenario/lockdown_scenario.py
+++ b/scenario/lockdown_scenario.py
@@ -11,7 +11,7 @@ from simulator.simulation_helper import get_environment_simulation, get_virus_si
 def launch_run():
 
     print('Preparing environment...')
-    env_dic = get_environment_simulation(params[nindividual_key], params[same_house_p_key],
+    env_dic = get_environment_simulation(params[nindividual_key],
                                          params[store_per_house_key], params[store_preference_key],
                                          params[nb_block_key], params[remote_work_key])
 

--- a/simulator/simulation_helper.py
+++ b/simulator/simulation_helper.py
@@ -7,9 +7,9 @@ from initiator.helper import get_r, get_infection_parameters
 from simulator.keys import *
 
 
-def get_environment_simulation(number_of_individuals_arg, same_house_rate_arg, number_store_per_house_arg,
+def get_environment_simulation(number_of_individuals_arg, number_store_per_house_arg,
                                preference_store_arg, nb_block_arg, probability_remote_work_arg):
-    indiv_house = build_individual_houses_map(number_of_individuals_arg, same_house_rate_arg)
+    indiv_house = build_individual_houses_map(number_of_individuals_arg)
     house_indiv = build_house_individual_map(indiv_house)
     indiv_adult = build_individual_adult_map(indiv_house)
     indiv_age = build_individual_age_map(indiv_house)

--- a/tests/initiator_test.py
+++ b/tests/initiator_test.py
@@ -1,4 +1,5 @@
 import random
+import numpy as np
 import unittest
 
 import numpy
@@ -14,22 +15,20 @@ class TestInitiation(unittest.TestCase):
     @classmethod
     def setUp(cls):
         random.seed(12)
+        np.random.seed(seed=12)
 
-    def test_build_individual_houses_map__big_families(self):
-        result = build_individual_houses_map(5, 0.1)
-        self.assertEqual(result, {0: 0, 1: 0, 2: 0, 3: 0, 4: 1})
+    def test_build_individual_houses_map__first_families(self):
+        result = build_individual_houses_map(5)
+        self.assertEqual(result, {0: 0, 1: 0, 2: 1, 3: 1, 4: 1})
 
-    def test_build_individual_houses_map__medium_families(self):
-        result = build_individual_houses_map(5, 0.5)
-        self.assertEqual(result, {0: 0, 1: 1, 2: 1, 3: 2, 4: 2})
+    def test_build_individual_houses_map__second_families(self):
+        result = build_individual_houses_map(10)
+        self.assertEqual(result, {0: 0, 1: 0, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2, 8: 2, 9: 2})
 
-    def test_build_individual_houses_map__small_families(self):
-        result = build_individual_houses_map(5, 0.95)
-        self.assertEqual(result, {0: 0, 1: 1, 2: 2, 3: 3, 4: 4})
-
-    def test_build_individual_houses_map__average_american_household(self):
-        result = build_individual_houses_map(100, 0.17)
-        self.assertEqual(numpy.mean([len(v) for k, v in invert_map(result).items()]), 2.5)
+    def test_build_individual_houses_map__average_moroccan_household(self):
+        result = build_individual_houses_map(1000)
+        mean_family=numpy.mean([len(v) for k, v in invert_map(result).items()])
+        self.assertEqual(abs(mean_family-4.52)<0.3, True)
 
     def test_build_individual_adult_map(self):
         input_individual_houses_map = {

--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -1,4 +1,5 @@
 import random
+import numpy as np
 import unittest
 
 from initiator.helper import get_infection_parameters
@@ -19,6 +20,7 @@ class TestSimulation(unittest.TestCase):
     @classmethod
     def setUp(cls):
         random.seed(12)
+        np.random.seed(seed=12)
 
     @staticmethod
     def get_virus_dic():
@@ -55,10 +57,25 @@ class TestSimulation(unittest.TestCase):
             WI_K: {0: [5], 1: [4, 1]},
             ITI_K: {1: {1, 4, 5}, 4: {1, 4, 5}, 5: {1, 4, 5}}
         }
+        # to avoid changing all the test values, I added this Dict to test "get_environment_simulation"
+        # and the other tests will be done with the old values =>get_10_01_2_environment_dic
+    def get_10_01_2_environment_new_house_map_dic():
+        return {
+            IH_K: {0: 0, 1: 0, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2, 8: 2, 9: 2},
+            HI_K: {0: [0, 1], 1: [2, 3, 4, 5, 6], 2: [7, 8, 9]},
+            IAD_K: {0: 1, 1: 1, 2: 1, 3: 1, 4: 0, 5: 0, 6: 0, 7: 1, 8: 1, 9: 0},
+            IAG_K: {0: 30, 1: 47, 2: 33, 3: 23, 4: 2, 5: 15, 6: 13, 7: 26, 8: 37, 9: 0},
+            IW_K: {2: 0, 1: 1},
+            WI_K:{0: [2], 1: [1]},
+            HA_K: {0: [0, 1], 1: [2, 3], 2: [7, 8]},
+            HS_K: {0: 0, 1: 0, 2: 0},
+            SH_K: {0: [0, 1, 2]},
+            ITI_K: {2: {1, 2}, 1: {1, 2}}
+            }
 
     def test_build_environment_dic(self):
-        result = get_environment_simulation(10, 0.1, 2, 1, 5, 0.5)
-        expected_result = TestSimulation.get_10_01_2_environment_dic()
+        result = get_environment_simulation(10, 2, 1, 5, 0.5)
+        expected_result = TestSimulation.get_10_01_2_environment_new_house_map_dic()
         self.assertEqual(result, expected_result)
 
     def test_build_virus_dic(self):


### PR DESCRIPTION
I add truncated normal distribution with a support on [1,10]. the density function is slightly different than the density of a normal distribution on a support IR, but  no serious  effects. 
I changed also unit tests , all tests pass except the **initiator_test**,  there is a problem with "test_build_individual_work_blocks" but that was the case before my changes 